### PR TITLE
Update to onnx 1.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "^0.6.1"
-bytes = "^0.5.0"
+prost = "0.10.0"
+bytes = "1.1.0"
 
 [build-dependencies]
-prost-build = "^0.6.1"
+prost-build = "0.10.0"


### PR DESCRIPTION
This patch update the 3rd party onnx repo to 1.11.0 and update dependency versions.